### PR TITLE
Naming changes

### DIFF
--- a/backend/cards/types.go
+++ b/backend/cards/types.go
@@ -1,6 +1,8 @@
 package cards
 
 import (
+	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/google/uuid"
@@ -119,4 +121,52 @@ func toCards(cards []scryfallCard) []Card {
 		result[i] = toCard(card)
 	}
 	return result
+}
+
+func GetCardAmounts(cards []Card, previews []CardAmountPreview) ([]CardAmount, error) {
+	amounts := make([]CardAmount, len(previews))
+	cardMap := make(map[uuid.UUID]Card, len(cards))
+
+	for _, card := range cards {
+		cardMap[card.ScryfallId] = card
+	}
+
+	for i, deposit := range previews {
+		card, ok := cardMap[deposit.ScryfallId]
+		if !ok {
+			return nil, fmt.Errorf("cannot resolve card id %s", deposit.ScryfallId)
+		}
+		amounts[i] = CardAmount{
+			Card:   card,
+			Amount: deposit.Amount,
+		}
+	}
+
+	slices.SortFunc(amounts, func(a, b CardAmount) int {
+		nameCompare := strings.Compare(a.Name, b.Name)
+		if nameCompare == 0 {
+			return strings.Compare(a.Set, b.Set)
+		}
+		return nameCompare
+	})
+
+	return amounts, nil
+}
+
+func GetScryfallIds(amounts []CardAmountPreview) []ScryfallIdentifier {
+	uniqIds := map[uuid.UUID]any{}
+
+	for _, deposit := range amounts {
+		uniqIds[deposit.ScryfallId] = nil
+	}
+
+	allIds := make([]ScryfallIdentifier, len(uniqIds))
+	i := 0
+
+	for id := range uniqIds {
+		allIds[i] = ScryfallIdentifier{Id: id}
+		i += 1
+	}
+
+	return allIds
 }

--- a/backend/cards/types.go
+++ b/backend/cards/types.go
@@ -130,15 +130,15 @@ func ToScryfallIds(amounts []CardAmountPreview) []ScryfallIdentifier {
 		uniqIds[deposit.ScryfallId] = nil
 	}
 
-	allIds := make([]ScryfallIdentifier, len(uniqIds))
+	ids := make([]ScryfallIdentifier, len(uniqIds))
 	i := 0
 
 	for id := range uniqIds {
-		allIds[i] = ScryfallIdentifier{Id: id}
+		ids[i] = ScryfallIdentifier{Id: id}
 		i += 1
 	}
 
-	return allIds
+	return ids
 }
 
 func JoinCardAmounts(cards []Card, previews []CardAmountPreview) ([]CardAmount, error) {

--- a/backend/cards/types.go
+++ b/backend/cards/types.go
@@ -32,6 +32,11 @@ type CardAmount struct {
 	Amount int `json:"amount"`
 }
 
+type CardAmountPreview struct {
+	ScryfallId uuid.UUID
+	Amount     int
+}
+
 type SearchCardPage struct {
 	TotalCards int
 	Cards      []Card

--- a/backend/cards/types.go
+++ b/backend/cards/types.go
@@ -123,7 +123,25 @@ func toCards(cards []scryfallCard) []Card {
 	return result
 }
 
-func GetCardAmounts(cards []Card, previews []CardAmountPreview) ([]CardAmount, error) {
+func ToScryfallIds(amounts []CardAmountPreview) []ScryfallIdentifier {
+	uniqIds := map[uuid.UUID]any{}
+
+	for _, deposit := range amounts {
+		uniqIds[deposit.ScryfallId] = nil
+	}
+
+	allIds := make([]ScryfallIdentifier, len(uniqIds))
+	i := 0
+
+	for id := range uniqIds {
+		allIds[i] = ScryfallIdentifier{Id: id}
+		i += 1
+	}
+
+	return allIds
+}
+
+func JoinCardAmounts(cards []Card, previews []CardAmountPreview) ([]CardAmount, error) {
 	amounts := make([]CardAmount, len(previews))
 	cardMap := make(map[uuid.UUID]Card, len(cards))
 
@@ -151,22 +169,4 @@ func GetCardAmounts(cards []Card, previews []CardAmountPreview) ([]CardAmount, e
 	})
 
 	return amounts, nil
-}
-
-func GetScryfallIds(amounts []CardAmountPreview) []ScryfallIdentifier {
-	uniqIds := map[uuid.UUID]any{}
-
-	for _, deposit := range amounts {
-		uniqIds[deposit.ScryfallId] = nil
-	}
-
-	allIds := make([]ScryfallIdentifier, len(uniqIds))
-	i := 0
-
-	for id := range uniqIds {
-		allIds[i] = ScryfallIdentifier{Id: id}
-		i += 1
-	}
-
-	return allIds
 }

--- a/backend/containers/repository.go
+++ b/backend/containers/repository.go
@@ -7,6 +7,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/jnie1/MTGViewer-V2/database"
 	"github.com/lib/pq"
+
+	"github.com/jnie1/MTGViewer-V2/cards"
 )
 
 func GetAllocations() ([]ContainerAllocation, error) {
@@ -80,7 +82,7 @@ func GetContainer(containerId int) (Container, error) {
 	return container, err
 }
 
-func GetDeposits(containerId int) ([]CardDepositPreview, error) {
+func GetDeposits(containerId int) ([]cards.CardAmountPreview, error) {
 	db := database.Instance()
 
 	row, err := db.Query(`
@@ -93,11 +95,10 @@ func GetDeposits(containerId int) ([]CardDepositPreview, error) {
 	}
 
 	defer row.Close()
-
-	deposits := []CardDepositPreview{}
+	deposits := []cards.CardAmountPreview{}
 
 	for row.Next() {
-		deposit := CardDepositPreview{}
+		deposit := cards.CardAmountPreview{}
 		if err := row.Scan(&deposit.ScryfallId, &deposit.Amount); err != nil {
 			return nil, err
 		}
@@ -108,7 +109,7 @@ func GetDeposits(containerId int) ([]CardDepositPreview, error) {
 	return deposits, nil
 }
 
-func SearchCards(scryfallIds uuid.UUIDs) ([]CardDeposit, error) {
+func SearchCards(scryfallIds uuid.UUIDs) ([]CardDepositPreview, error) {
 	db := database.Instance()
 
 	row, err := db.Query(`
@@ -123,10 +124,10 @@ func SearchCards(scryfallIds uuid.UUIDs) ([]CardDeposit, error) {
 
 	defer row.Close()
 
-	deposits := []CardDeposit{}
+	deposits := []CardDepositPreview{}
 
 	for row.Next() {
-		deposit := CardDeposit{}
+		deposit := CardDepositPreview{}
 		if err := row.Scan(&deposit.ContainerId, &deposit.ContainerName, &deposit.ScryfallId, &deposit.Amount); err != nil {
 			return nil, err
 		}

--- a/backend/containers/repository.go
+++ b/backend/containers/repository.go
@@ -82,7 +82,7 @@ func GetContainer(containerId int) (Container, error) {
 	return container, err
 }
 
-func GetAmountPreviews(containerId int) ([]cards.CardAmountPreview, error) {
+func GetAmounts(containerId int) ([]cards.CardAmountPreview, error) {
 	db := database.Instance()
 
 	row, err := db.Query(`
@@ -109,7 +109,7 @@ func GetAmountPreviews(containerId int) ([]cards.CardAmountPreview, error) {
 	return deposits, nil
 }
 
-func SearchCards(scryfallIds uuid.UUIDs) ([]CardDepositPreview, error) {
+func SearchDeposits(scryfallIds uuid.UUIDs) ([]CardDepositPreview, error) {
 	db := database.Instance()
 
 	row, err := db.Query(`

--- a/backend/containers/repository.go
+++ b/backend/containers/repository.go
@@ -82,7 +82,7 @@ func GetContainer(containerId int) (Container, error) {
 	return container, err
 }
 
-func GetDeposits(containerId int) ([]cards.CardAmountPreview, error) {
+func GetAmountPreviews(containerId int) ([]cards.CardAmountPreview, error) {
 	db := database.Instance()
 
 	row, err := db.Query(`

--- a/backend/containers/repository.go
+++ b/backend/containers/repository.go
@@ -95,18 +95,18 @@ func GetAmounts(containerId int) ([]cards.CardAmountPreview, error) {
 	}
 
 	defer row.Close()
-	deposits := []cards.CardAmountPreview{}
+	amounts := []cards.CardAmountPreview{}
 
 	for row.Next() {
-		deposit := cards.CardAmountPreview{}
-		if err := row.Scan(&deposit.ScryfallId, &deposit.Amount); err != nil {
+		amount := cards.CardAmountPreview{}
+		if err := row.Scan(&amount.ScryfallId, &amount.Amount); err != nil {
 			return nil, err
 		}
 
-		deposits = append(deposits, deposit)
+		amounts = append(amounts, amount)
 	}
 
-	return deposits, nil
+	return amounts, nil
 }
 
 func SearchDeposits(scryfallIds uuid.UUIDs) ([]CardDepositPreview, error) {

--- a/backend/containers/types.go
+++ b/backend/containers/types.go
@@ -137,36 +137,6 @@ func MergeContainerChanges(changes []ContainerChanges) []ContainerChanges {
 	return mergedChanges
 }
 
-func GetCardAmounts(fullCards []cards.Card, deposits []cards.CardAmountPreview) ([]cards.CardAmount, error) {
-	amounts := make([]cards.CardAmount, len(deposits))
-	cardMap := make(map[uuid.UUID]cards.Card, len(fullCards))
-
-	for _, card := range fullCards {
-		cardMap[card.ScryfallId] = card
-	}
-
-	for i, deposit := range deposits {
-		card, ok := cardMap[deposit.ScryfallId]
-		if !ok {
-			return nil, fmt.Errorf("cannot resolve card id %s", deposit.ScryfallId)
-		}
-		amounts[i] = cards.CardAmount{
-			Card:   card,
-			Amount: deposit.Amount,
-		}
-	}
-
-	slices.SortFunc(amounts, func(a, b cards.CardAmount) int {
-		nameCompare := strings.Compare(a.Name, b.Name)
-		if nameCompare == 0 {
-			return strings.Compare(a.Set, b.Set)
-		}
-		return nameCompare
-	})
-
-	return amounts, nil
-}
-
 func GetCardDeposits(fullCards []cards.Card, deposits []CardDepositPreview) ([]CardDeposit, error) {
 	depositAmounts := make([]CardDeposit, len(deposits))
 	cardMap := make(map[uuid.UUID]cards.Card, len(fullCards))
@@ -193,24 +163,6 @@ func GetCardDeposits(fullCards []cards.Card, deposits []CardDepositPreview) ([]C
 	})
 
 	return depositAmounts, nil
-}
-
-func GetScryfallIds(deposits []cards.CardAmountPreview) []cards.ScryfallIdentifier {
-	uniqIds := map[uuid.UUID]any{}
-
-	for _, deposit := range deposits {
-		uniqIds[deposit.ScryfallId] = nil
-	}
-
-	allIds := make([]cards.ScryfallIdentifier, len(uniqIds))
-	i := 0
-
-	for id := range uniqIds {
-		allIds[i] = cards.ScryfallIdentifier{Id: id}
-		i += 1
-	}
-
-	return allIds
 }
 
 type csvHeaderPositions struct {

--- a/backend/containers/types.go
+++ b/backend/containers/types.go
@@ -167,7 +167,7 @@ func GetCardAmounts(fullCards []cards.Card, deposits []cards.CardAmountPreview) 
 	return amounts, nil
 }
 
-func GetCardDepositAmounts(fullCards []cards.Card, deposits []CardDepositPreview) ([]CardDeposit, error) {
+func GetCardDeposits(fullCards []cards.Card, deposits []CardDepositPreview) ([]CardDeposit, error) {
 	depositAmounts := make([]CardDeposit, len(deposits))
 	cardMap := make(map[uuid.UUID]cards.Card, len(fullCards))
 

--- a/backend/containers/types.go
+++ b/backend/containers/types.go
@@ -24,21 +24,16 @@ type Container struct {
 	IsDeleted bool   `json:"isDeleted"`
 }
 
-type CardDepositAmount struct {
+type CardDeposit struct {
 	ContainerId   int    `json:"containerId"`
 	ContainerName string `json:"containerName"`
 	cards.CardAmount
 }
 
 type CardDepositPreview struct {
-	ScryfallId uuid.UUID
-	Amount     int
-}
-
-type CardDeposit struct {
 	ContainerId   int
 	ContainerName string
-	CardDepositPreview
+	cards.CardAmountPreview
 }
 
 type CardRequest struct {
@@ -142,7 +137,7 @@ func MergeContainerChanges(changes []ContainerChanges) []ContainerChanges {
 	return mergedChanges
 }
 
-func GetCardAmounts(fullCards []cards.Card, deposits []CardDepositPreview) ([]cards.CardAmount, error) {
+func GetCardAmounts(fullCards []cards.Card, deposits []cards.CardAmountPreview) ([]cards.CardAmount, error) {
 	amounts := make([]cards.CardAmount, len(deposits))
 	cardMap := make(map[uuid.UUID]cards.Card, len(fullCards))
 
@@ -172,8 +167,8 @@ func GetCardAmounts(fullCards []cards.Card, deposits []CardDepositPreview) ([]ca
 	return amounts, nil
 }
 
-func GetCardDepositAmounts(fullCards []cards.Card, deposits []CardDeposit) ([]CardDepositAmount, error) {
-	depositAmounts := make([]CardDepositAmount, len(deposits))
+func GetCardDepositAmounts(fullCards []cards.Card, deposits []CardDepositPreview) ([]CardDeposit, error) {
+	depositAmounts := make([]CardDeposit, len(deposits))
 	cardMap := make(map[uuid.UUID]cards.Card, len(fullCards))
 
 	for _, card := range fullCards {
@@ -186,10 +181,10 @@ func GetCardDepositAmounts(fullCards []cards.Card, deposits []CardDeposit) ([]Ca
 			return nil, fmt.Errorf("cannot resolve card id %s", deposit.ScryfallId)
 		}
 		amount := cards.CardAmount{Card: card, Amount: deposit.Amount}
-		depositAmounts[i] = CardDepositAmount{CardAmount: amount, ContainerId: deposit.ContainerId, ContainerName: deposit.ContainerName}
+		depositAmounts[i] = CardDeposit{CardAmount: amount, ContainerId: deposit.ContainerId, ContainerName: deposit.ContainerName}
 	}
 
-	slices.SortFunc(depositAmounts, func(a, b CardDepositAmount) int {
+	slices.SortFunc(depositAmounts, func(a, b CardDeposit) int {
 		nameCompare := strings.Compare(a.Name, b.Name)
 		if nameCompare == 0 {
 			return strings.Compare(a.Set, b.Set)
@@ -200,7 +195,7 @@ func GetCardDepositAmounts(fullCards []cards.Card, deposits []CardDeposit) ([]Ca
 	return depositAmounts, nil
 }
 
-func GetScryfallIds(deposits []CardDepositPreview) []cards.ScryfallIdentifier {
+func GetScryfallIds(deposits []cards.CardAmountPreview) []cards.ScryfallIdentifier {
 	uniqIds := map[uuid.UUID]any{}
 
 	for _, deposit := range deposits {

--- a/backend/containers/types.go
+++ b/backend/containers/types.go
@@ -11,6 +11,19 @@ import (
 	"github.com/jnie1/MTGViewer-V2/cards"
 )
 
+type Container struct {
+	Name      string `json:"name"`
+	Used      int    `json:"used"`
+	Capacity  int    `json:"capacity"`
+	IsDeleted bool   `json:"isDeleted"`
+}
+
+type ContainerPreview struct {
+	ContainerId int    `json:"containerId"`
+	Name        string `json:"name"`
+	Capacity    int    `json:"capacity"`
+}
+
 type ContainerName struct {
 	ContainerId int    `json:"containerId"`
 	Name        string `json:"name"`
@@ -23,17 +36,9 @@ func (container *ContainerName) Container() ContainerName {
 	return *container
 }
 
-type ContainerPreview struct {
-	ContainerId int    `json:"containerId"`
-	Name        string `json:"name"`
-	Capacity    int    `json:"capacity"`
-}
-
-type Container struct {
-	Name      string `json:"name"`
-	Used      int    `json:"used"`
-	Capacity  int    `json:"capacity"`
-	IsDeleted bool   `json:"isDeleted"`
+type ContainerDelta struct {
+	ContainerId int
+	Delta       int
 }
 
 type CardDeposit struct {

--- a/backend/containers/types.go
+++ b/backend/containers/types.go
@@ -11,6 +11,18 @@ import (
 	"github.com/jnie1/MTGViewer-V2/cards"
 )
 
+type ContainerName struct {
+	ContainerId int    `json:"containerId"`
+	Name        string `json:"name"`
+}
+
+func (container *ContainerName) Container() ContainerName {
+	if container == nil {
+		return ContainerName{}
+	}
+	return *container
+}
+
 type ContainerPreview struct {
 	ContainerId int    `json:"containerId"`
 	Name        string `json:"name"`
@@ -39,6 +51,11 @@ type CardDepositPreview struct {
 type CardRequest struct {
 	ScryfallId uuid.UUID
 	Delta      int
+}
+
+type ContainerCard struct {
+	ContainerId int
+	ScryfallId  uuid.UUID
 }
 
 type ContainerChanges struct {

--- a/backend/containers/types.go
+++ b/backend/containers/types.go
@@ -137,7 +137,7 @@ func MergeContainerChanges(changes []ContainerChanges) []ContainerChanges {
 	return mergedChanges
 }
 
-func GetCardDeposits(fullCards []cards.Card, deposits []CardDepositPreview) ([]CardDeposit, error) {
+func JoinCardDeposits(fullCards []cards.Card, deposits []CardDepositPreview) ([]CardDeposit, error) {
 	depositAmounts := make([]CardDeposit, len(deposits))
 	cardMap := make(map[uuid.UUID]cards.Card, len(fullCards))
 

--- a/backend/containers/withdrawal.go
+++ b/backend/containers/withdrawal.go
@@ -88,7 +88,7 @@ type depositKey struct {
 	ScryfallId  uuid.UUID
 }
 
-func ValidateCardWithdrawals(withdrawals ContainerWithdrawals, deposits []CardDeposit) ([]ContainerChanges, error) {
+func ValidateCardWithdrawals(withdrawals ContainerWithdrawals, deposits []CardDepositPreview) ([]ContainerChanges, error) {
 	changes := []ContainerChanges{}
 	amountsByContainers := map[depositKey]int{}
 

--- a/backend/routes/cards.go
+++ b/backend/routes/cards.go
@@ -25,13 +25,13 @@ func fetchCollection(c *gin.Context) {
 		return
 	}
 
-	cards, err := cards.FetchCollection(scryfallIds)
+	result, err := cards.FetchCollection(scryfallIds)
 	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, cards)
+	c.JSON(http.StatusOK, result)
 }
 
 func fetchCard(c *gin.Context) {
@@ -43,24 +43,24 @@ func fetchCard(c *gin.Context) {
 		return
 	}
 
-	card, err := cards.FetchCard(cards.ScryfallIdentifier{Id: scryfallId})
+	result, err := cards.FetchCard(cards.ScryfallIdentifier{Id: scryfallId})
 	if err != nil {
 		c.AbortWithError(http.StatusNotFound, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, card)
+	c.JSON(http.StatusOK, result)
 }
 
 func fetchRandomCard(c *gin.Context) {
-	card, err := cards.FetchRandomCard()
+	result, err := cards.FetchRandomCard()
 
 	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, card)
+	c.JSON(http.StatusOK, result)
 }
 
 func importCards(c *gin.Context) {

--- a/backend/routes/cards.go
+++ b/backend/routes/cards.go
@@ -119,7 +119,7 @@ func withdrawCards(c *gin.Context) {
 	}
 
 	scryfallIds := containers.FindScryfallIds(withdrawals)
-	deposits, err := containers.SearchCards(scryfallIds)
+	deposits, err := containers.SearchDeposits(scryfallIds)
 	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)
 		return

--- a/backend/routes/containers.go
+++ b/backend/routes/containers.go
@@ -11,37 +11,35 @@ import (
 )
 
 func fetchContainerPreviews(c *gin.Context) {
-	containers, err := containers.GetContainers()
+	result, err := containers.GetContainers()
 	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, containers)
+	c.JSON(http.StatusOK, result)
 }
 
 func fetchContainer(c *gin.Context) {
 	id := c.Param("container")
 	containerId, err := strconv.Atoi(id)
-
 	if err != nil {
 		c.AbortWithStatus(http.StatusBadRequest)
 		return
 	}
 
-	container, err := containers.GetContainer(containerId)
+	result, err := containers.GetContainer(containerId)
 	if err != nil {
 		c.AbortWithError(http.StatusNotFound, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, container)
+	c.JSON(http.StatusOK, result)
 }
 
 func fetchContainerCards(c *gin.Context) {
 	id := c.Param("container")
 	containerId, err := strconv.Atoi(id)
-
 	if err != nil {
 		c.AbortWithStatus(http.StatusBadRequest)
 		return

--- a/backend/routes/containers.go
+++ b/backend/routes/containers.go
@@ -85,7 +85,7 @@ func searchCards(c *gin.Context) {
 	}
 
 	if len(cardPage.Cards) == 0 {
-		c.JSON(http.StatusOK, []containers.CardDepositAmount{})
+		c.JSON(http.StatusOK, []containers.CardDeposit{})
 		return
 	}
 

--- a/backend/routes/containers.go
+++ b/backend/routes/containers.go
@@ -47,32 +47,31 @@ func fetchContainerCards(c *gin.Context) {
 		return
 	}
 
-	previews, err := containers.GetAmountPreviews(containerId)
+	amounts, err := containers.GetAmounts(containerId)
 	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)
 		return
 	}
 
-	if len(previews) == 0 {
+	if len(amounts) == 0 {
 		c.JSON(http.StatusOK, []cards.CardAmount{})
 		return
 	}
 
-	scryfallIds := cards.GetScryfallIds(previews)
+	scryfallIds := cards.ToScryfallIds(amounts)
 	matches, err := cards.FetchCollection(scryfallIds)
-
 	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)
 		return
 	}
 
-	amounts, err := cards.GetCardAmounts(matches, previews)
+	result, err := cards.JoinCardAmounts(matches, amounts)
 	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, amounts)
+	c.JSON(http.StatusOK, result)
 }
 
 func searchCards(c *gin.Context) {
@@ -94,19 +93,19 @@ func searchCards(c *gin.Context) {
 		cardIds[i] = card.ScryfallId
 	}
 
-	deposits, err := containers.SearchCards(cardIds)
+	deposits, err := containers.SearchDeposits(cardIds)
 	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)
 		return
 	}
 
-	cardAmounts, err := containers.GetCardDeposits(cardPage.Cards, deposits)
+	result, err := containers.JoinCardDeposits(cardPage.Cards, deposits)
 	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, cardAmounts)
+	c.JSON(http.StatusOK, result)
 }
 
 func AddContainerRoutes(router *gin.Engine) {

--- a/backend/routes/containers.go
+++ b/backend/routes/containers.go
@@ -100,7 +100,7 @@ func searchCards(c *gin.Context) {
 		return
 	}
 
-	cardAmounts, err := containers.GetCardDepositAmounts(cardPage.Cards, deposits)
+	cardAmounts, err := containers.GetCardDeposits(cardPage.Cards, deposits)
 	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)
 		return

--- a/backend/routes/containers.go
+++ b/backend/routes/containers.go
@@ -47,32 +47,32 @@ func fetchContainerCards(c *gin.Context) {
 		return
 	}
 
-	deposits, err := containers.GetDeposits(containerId)
+	previews, err := containers.GetAmountPreviews(containerId)
 	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)
 		return
 	}
 
-	if len(deposits) == 0 {
+	if len(previews) == 0 {
 		c.JSON(http.StatusOK, []cards.CardAmount{})
 		return
 	}
 
-	scryfallIds := containers.GetScryfallIds(deposits)
-	cards, err := cards.FetchCollection(scryfallIds)
+	scryfallIds := cards.GetScryfallIds(previews)
+	matches, err := cards.FetchCollection(scryfallIds)
 
 	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)
 		return
 	}
 
-	cardAmounts, err := containers.GetCardAmounts(cards, deposits)
+	amounts, err := cards.GetCardAmounts(matches, previews)
 	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, cardAmounts)
+	c.JSON(http.StatusOK, amounts)
 }
 
 func searchCards(c *gin.Context) {

--- a/backend/routes/transactions.go
+++ b/backend/routes/transactions.go
@@ -9,17 +9,17 @@ import (
 	"github.com/jnie1/MTGViewer-V2/transactions"
 )
 
-func fetchUpdateLogs(c *gin.Context) {
-	logs, err := transactions.FetchUpdateLogs()
+func fetchCardTransactions(c *gin.Context) {
+	result, err := transactions.GetTransactions()
 	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, logs)
+	c.JSON(http.StatusOK, result)
 }
 
-func fetchReportCards(c *gin.Context) {
+func fetchCardLogs(c *gin.Context) {
 	group := c.Param("group")
 	group1, err := uuid.Parse(group)
 
@@ -37,43 +37,43 @@ func fetchReportCards(c *gin.Context) {
 		}
 	}
 
-	allLogs, err := fetchTransactionLogs(group1, group2)
+	allLogs, err := getLogs(group1, group2)
 	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)
 		return
 	}
 
 	logs := transactions.MergeLogs(allLogs)
-	scryfallIds := transactions.GetScryfallIds(logs)
-	cards, err := cards.FetchCollection(scryfallIds)
+	scryfallIds := transactions.ToScryfallIds(logs)
+	matches, err := cards.FetchCollection(scryfallIds)
 
 	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)
 		return
 	}
 
-	reportCards, err := transactions.JoinReportCards(cards, logs)
+	result, err := transactions.JoinCardLogs(matches, logs)
 	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, reportCards)
+	c.JSON(http.StatusOK, result)
 }
 
-func fetchTransactionLogs(group1, group2 uuid.UUID) ([]transactions.TransactionLogs, error) {
+func getLogs(group1, group2 uuid.UUID) ([]transactions.CardLogPreview, error) {
 	if group2 == uuid.Nil {
-		return transactions.FetchLogs(group1)
+		return transactions.GetLogs(group1)
 	}
-	logRange, err := transactions.FetchLogRange(group1, group2)
+	logRange, err := transactions.GetTimeRange(group1, group2)
 	if err != nil {
 		return nil, err
 	}
-	return transactions.FetchLogsFromRange(logRange)
+	return transactions.GetLogsFromRange(logRange)
 }
 
 func AddTransactionRoutes(router *gin.Engine) {
 	group := router.Group("/logs")
-	group.GET("", fetchUpdateLogs)
-	group.GET("/:group", fetchReportCards)
+	group.GET("", fetchCardTransactions)
+	group.GET("/:group", fetchCardLogs)
 }

--- a/backend/transactions/merge.go
+++ b/backend/transactions/merge.go
@@ -5,25 +5,26 @@ import (
 	"slices"
 
 	"github.com/google/uuid"
+	"github.com/jnie1/MTGViewer-V2/containers"
 )
 
-func MergeLogs(logs []TransactionLogs) []TransactionLogs {
-	containerDeltas := map[containerCard]int{}
-	containersById := map[int]*TransactionContainer{}
+func MergeLogs(logs []CardLogPreview) []CardLogPreview {
+	containerDeltas := map[containers.ContainerCard]int{}
+	containersById := containerMappings{}
 
 	for _, log := range logs {
 		if log.FromContainer != nil {
 			containerId := log.FromContainer.ContainerId
-			key := containerCard{containerId, log.ScryfallId}
+			key := containers.ContainerCard{ContainerId: containerId, ScryfallId: log.ScryfallId}
 
-			containerDeltas[key] = containerDeltas[key] - log.Quantity
+			containerDeltas[key] = containerDeltas[key] - log.Amount
 			containersById[containerId] = log.FromContainer
 		}
 		if log.ToContainer != nil {
 			containerId := log.ToContainer.ContainerId
-			key := containerCard{containerId, log.ScryfallId}
+			key := containers.ContainerCard{ContainerId: containerId, ScryfallId: log.ScryfallId}
 
-			containerDeltas[key] = containerDeltas[key] + log.Quantity
+			containerDeltas[key] = containerDeltas[key] + log.Amount
 			containersById[containerId] = log.ToContainer
 		}
 	}
@@ -31,16 +32,16 @@ func MergeLogs(logs []TransactionLogs) []TransactionLogs {
 	changesByCard := map[uuid.UUID][]containerChange{}
 
 	for key, delta := range containerDeltas {
-		cardId := key.scryfallId
-		newChange := containerChange{key.containerId, delta}
+		cardId := key.ScryfallId
+		newChange := containerChange{key.ContainerId, delta}
 		changesByCard[cardId] = append(changesByCard[cardId], newChange)
 	}
 
 	return combineCardDeltas(changesByCard, containersById)
 }
 
-func combineCardDeltas(deltas map[uuid.UUID][]containerChange, containers map[int]*TransactionContainer) []TransactionLogs {
-	updatedLogs := []TransactionLogs{}
+func combineCardDeltas(deltas map[uuid.UUID][]containerChange, containers containerMappings) []CardLogPreview {
+	updatedLogs := []CardLogPreview{}
 
 	for cardId, changes := range deltas {
 		adds := []containerChange{}
@@ -75,14 +76,14 @@ func combineCardDeltas(deltas map[uuid.UUID][]containerChange, containers map[in
 
 		for currentAdd.delta > 0 && currentDelete.delta < 0 {
 			add, delete := currentAdd.delta, -currentDelete.delta
-			newLog := TransactionLogs{
+			newLog := CardLogPreview{
 				FromContainer: containers[currentDelete.containerId],
 				ToContainer:   containers[currentAdd.containerId],
 				ScryfallId:    cardId,
 			}
 
 			if add < delete {
-				newLog.Quantity = add
+				newLog.Amount = add
 
 				addIndex += 1
 				if addIndex < len(adds) {
@@ -96,7 +97,7 @@ func combineCardDeltas(deltas map[uuid.UUID][]containerChange, containers map[in
 					delta:       currentDelete.delta + add,
 				}
 			} else if add > delete {
-				newLog.Quantity = delete
+				newLog.Amount = delete
 
 				deleteIndex += 1
 				if deleteIndex < len(deletes) {
@@ -110,7 +111,7 @@ func combineCardDeltas(deltas map[uuid.UUID][]containerChange, containers map[in
 					delta:       currentAdd.delta - delete,
 				}
 			} else {
-				newLog.Quantity = add
+				newLog.Amount = add
 
 				addIndex += 1
 				if addIndex < len(adds) {
@@ -131,36 +132,36 @@ func combineCardDeltas(deltas map[uuid.UUID][]containerChange, containers map[in
 		}
 
 		if currentAdd.delta > 0 {
-			updatedLogs = append(updatedLogs, TransactionLogs{
+			updatedLogs = append(updatedLogs, CardLogPreview{
 				ToContainer: containers[currentAdd.containerId],
 				ScryfallId:  cardId,
-				Quantity:    currentAdd.delta,
+				Amount:      currentAdd.delta,
 			})
 
 			if addIndex+1 < len(adds) {
 				for _, extra := range adds[addIndex+1:] {
-					updatedLogs = append(updatedLogs, TransactionLogs{
+					updatedLogs = append(updatedLogs, CardLogPreview{
 						ToContainer: containers[extra.containerId],
 						ScryfallId:  cardId,
-						Quantity:    extra.delta,
+						Amount:      extra.delta,
 					})
 				}
 			}
 		}
 
 		if currentDelete.delta < 0 {
-			updatedLogs = append(updatedLogs, TransactionLogs{
+			updatedLogs = append(updatedLogs, CardLogPreview{
 				FromContainer: containers[currentDelete.containerId],
 				ScryfallId:    cardId,
-				Quantity:      -currentDelete.delta,
+				Amount:        -currentDelete.delta,
 			})
 
 			if deleteIndex+1 < len(deletes) {
 				for _, extra := range deletes[deleteIndex+1:] {
-					updatedLogs = append(updatedLogs, TransactionLogs{
+					updatedLogs = append(updatedLogs, CardLogPreview{
 						FromContainer: containers[extra.containerId],
 						ScryfallId:    cardId,
-						Quantity:      -extra.delta,
+						Amount:        -extra.delta,
 					})
 				}
 			}

--- a/backend/transactions/merge.go
+++ b/backend/transactions/merge.go
@@ -9,106 +9,101 @@ import (
 )
 
 func MergeLogs(logs []CardLogPreview) []CardLogPreview {
-	containerDeltas := map[containers.ContainerCard]int{}
-	containersById := containerMappings{}
+	changesByContainer := map[containers.ContainerCard]int{}
+	containersById := map[int]*containers.ContainerName{}
 
 	for _, log := range logs {
 		if log.FromContainer != nil {
 			containerId := log.FromContainer.ContainerId
 			key := containers.ContainerCard{ContainerId: containerId, ScryfallId: log.ScryfallId}
 
-			containerDeltas[key] = containerDeltas[key] - log.Amount
+			changesByContainer[key] = changesByContainer[key] - log.Amount
 			containersById[containerId] = log.FromContainer
 		}
 		if log.ToContainer != nil {
 			containerId := log.ToContainer.ContainerId
 			key := containers.ContainerCard{ContainerId: containerId, ScryfallId: log.ScryfallId}
 
-			containerDeltas[key] = containerDeltas[key] + log.Amount
+			changesByContainer[key] = changesByContainer[key] + log.Amount
 			containersById[containerId] = log.ToContainer
 		}
 	}
 
-	changesByCard := map[uuid.UUID][]containerChange{}
-
-	for key, delta := range containerDeltas {
-		cardId := key.ScryfallId
-		newChange := containerChange{key.ContainerId, delta}
+	changesByCard := map[uuid.UUID][]containers.ContainerDelta{}
+	for cardKey, delta := range changesByContainer {
+		cardId := cardKey.ScryfallId
+		newChange := containers.ContainerDelta{ContainerId: cardKey.ContainerId, Delta: delta}
 		changesByCard[cardId] = append(changesByCard[cardId], newChange)
 	}
 
-	return combineCardDeltas(changesByCard, containersById)
-}
-
-func combineCardDeltas(deltas map[uuid.UUID][]containerChange, containers containerMappings) []CardLogPreview {
 	updatedLogs := []CardLogPreview{}
 
-	for cardId, changes := range deltas {
-		adds := []containerChange{}
-		deletes := []containerChange{}
+	for cardId, changes := range changesByCard {
+		adds := []containers.ContainerDelta{}
+		dels := []containers.ContainerDelta{}
 
 		for _, change := range changes {
-			if change.delta > 0 {
+			if change.Delta > 0 {
 				adds = append(adds, change)
-			} else if change.delta < 0 {
-				deletes = append(deletes, change)
+			} else if change.Delta < 0 {
+				dels = append(dels, change)
 			}
 		}
 
-		slices.SortFunc(adds, func(a, b containerChange) int {
+		slices.SortFunc(adds, func(a, b containers.ContainerDelta) int {
 			// sort largest adds first, the most positive number desc
-			return -cmp.Compare(a.delta, b.delta)
+			return -cmp.Compare(a.Delta, b.Delta)
 		})
-		slices.SortFunc(deletes, func(a, b containerChange) int {
+		slices.SortFunc(dels, func(a, b containers.ContainerDelta) int {
 			// sort largest deletes first, most negative number asc
-			return cmp.Compare(a.delta, b.delta)
+			return cmp.Compare(a.Delta, b.Delta)
 		})
 
-		var currentAdd, currentDelete containerChange
+		var currentAdd, currentDelete containers.ContainerDelta
 		addIndex, deleteIndex := 0, 0
 
 		if addIndex < len(adds) {
 			currentAdd = adds[addIndex]
 		}
-		if deleteIndex < len(deletes) {
-			currentDelete = deletes[deleteIndex]
+		if deleteIndex < len(dels) {
+			currentDelete = dels[deleteIndex]
 		}
 
-		for currentAdd.delta > 0 && currentDelete.delta < 0 {
-			add, delete := currentAdd.delta, -currentDelete.delta
+		for currentAdd.Delta > 0 && currentDelete.Delta < 0 {
+			add, del := currentAdd.Delta, -currentDelete.Delta
 			newLog := CardLogPreview{
-				FromContainer: containers[currentDelete.containerId],
-				ToContainer:   containers[currentAdd.containerId],
+				FromContainer: containersById[currentDelete.ContainerId],
+				ToContainer:   containersById[currentAdd.ContainerId],
 				ScryfallId:    cardId,
 			}
 
-			if add < delete {
+			if add < del {
 				newLog.Amount = add
 
 				addIndex += 1
 				if addIndex < len(adds) {
 					currentAdd = adds[addIndex]
 				} else {
-					currentAdd = containerChange{}
+					currentAdd = containers.ContainerDelta{}
 				}
 
-				currentDelete = containerChange{
-					containerId: currentDelete.containerId,
-					delta:       currentDelete.delta + add,
+				currentDelete = containers.ContainerDelta{
+					ContainerId: currentDelete.ContainerId,
+					Delta:       currentDelete.Delta + add,
 				}
-			} else if add > delete {
-				newLog.Amount = delete
+			} else if add > del {
+				newLog.Amount = del
 
 				deleteIndex += 1
-				if deleteIndex < len(deletes) {
-					currentDelete = deletes[deleteIndex]
+				if deleteIndex < len(dels) {
+					currentDelete = dels[deleteIndex]
 				} else {
-					currentDelete = containerChange{}
+					currentDelete = containers.ContainerDelta{}
 				}
 
-				currentAdd = containerChange{
-					containerId: currentAdd.containerId,
-					delta:       currentAdd.delta - delete,
+				currentAdd = containers.ContainerDelta{
+					ContainerId: currentAdd.ContainerId,
+					Delta:       currentAdd.Delta - del,
 				}
 			} else {
 				newLog.Amount = add
@@ -117,51 +112,51 @@ func combineCardDeltas(deltas map[uuid.UUID][]containerChange, containers contai
 				if addIndex < len(adds) {
 					currentAdd = adds[addIndex]
 				} else {
-					currentAdd = containerChange{}
+					currentAdd = containers.ContainerDelta{}
 				}
 
 				deleteIndex += 1
-				if deleteIndex < len(deletes) {
-					currentDelete = deletes[deleteIndex]
+				if deleteIndex < len(dels) {
+					currentDelete = dels[deleteIndex]
 				} else {
-					currentDelete = containerChange{}
+					currentDelete = containers.ContainerDelta{}
 				}
 			}
 
 			updatedLogs = append(updatedLogs, newLog)
 		}
 
-		if currentAdd.delta > 0 {
+		if currentAdd.Delta > 0 {
 			updatedLogs = append(updatedLogs, CardLogPreview{
-				ToContainer: containers[currentAdd.containerId],
+				ToContainer: containersById[currentAdd.ContainerId],
 				ScryfallId:  cardId,
-				Amount:      currentAdd.delta,
+				Amount:      currentAdd.Delta,
 			})
 
 			if addIndex+1 < len(adds) {
 				for _, extra := range adds[addIndex+1:] {
 					updatedLogs = append(updatedLogs, CardLogPreview{
-						ToContainer: containers[extra.containerId],
+						ToContainer: containersById[extra.ContainerId],
 						ScryfallId:  cardId,
-						Amount:      extra.delta,
+						Amount:      extra.Delta,
 					})
 				}
 			}
 		}
 
-		if currentDelete.delta < 0 {
+		if currentDelete.Delta < 0 {
 			updatedLogs = append(updatedLogs, CardLogPreview{
-				FromContainer: containers[currentDelete.containerId],
+				FromContainer: containersById[currentDelete.ContainerId],
 				ScryfallId:    cardId,
-				Amount:        -currentDelete.delta,
+				Amount:        -currentDelete.Delta,
 			})
 
-			if deleteIndex+1 < len(deletes) {
-				for _, extra := range deletes[deleteIndex+1:] {
+			if deleteIndex+1 < len(dels) {
+				for _, extra := range dels[deleteIndex+1:] {
 					updatedLogs = append(updatedLogs, CardLogPreview{
-						FromContainer: containers[extra.containerId],
+						FromContainer: containersById[extra.ContainerId],
 						ScryfallId:    cardId,
-						Amount:        -extra.delta,
+						Amount:        -extra.Delta,
 					})
 				}
 			}

--- a/backend/transactions/repository.go
+++ b/backend/transactions/repository.go
@@ -11,7 +11,7 @@ import (
 	"github.com/jnie1/MTGViewer-V2/database"
 )
 
-func FetchLogRange(group1, group2 uuid.UUID) (LogRange, error) {
+func GetTimeRange(group1, group2 uuid.UUID) (LogRange, error) {
 	db := database.Instance()
 
 	row := db.QueryRow(`
@@ -20,15 +20,15 @@ func FetchLogRange(group1, group2 uuid.UUID) (LogRange, error) {
 		WHERE group_id = $1 OR group_id = $2;`, group1, group2)
 
 	logRange := LogRange{}
-	err := row.Scan(&logRange.start, &logRange.end)
+	err := row.Scan(&logRange.Start, &logRange.End)
 
 	return logRange, err
 }
 
-func FetchUpdateLogs() ([]UpdateLogs, error) {
+func GetTransactions() ([]CardTransaction, error) {
 	db := database.Instance()
 	row, err := db.Query(`
-		SELECT group_id, time, SUM(amount) AS amount
+		SELECT group_id, time, SUM(amount) AS total
 		FROM transactions
 		GROUP BY group_id, time
 		ORDER BY time DESC;`)
@@ -38,22 +38,22 @@ func FetchUpdateLogs() ([]UpdateLogs, error) {
 	}
 
 	defer row.Close()
-	logs := []UpdateLogs{}
+	transactions := []CardTransaction{}
 
 	for row.Next() {
-		log := UpdateLogs{}
+		transaction := CardTransaction{}
 
-		if err := row.Scan(&log.GroupId, &log.Time, &log.Amount); err != nil {
+		if err := row.Scan(&transaction.GroupId, &transaction.Time, &transaction.Total); err != nil {
 			return nil, err
 		}
 
-		logs = append(logs, log)
+		transactions = append(transactions, transaction)
 	}
 
-	return logs, nil
+	return transactions, nil
 }
 
-func FetchLogs(groupId uuid.UUID) ([]TransactionLogs, error) {
+func GetLogs(groupId uuid.UUID) ([]CardLogPreview, error) {
 	db := database.Instance()
 	row, err := db.Query(`
 		SELECT fc.container_id, fc.container_name, tc.container_id, tc.container_name, scryfall_id, amount
@@ -67,31 +67,31 @@ func FetchLogs(groupId uuid.UUID) ([]TransactionLogs, error) {
 	}
 
 	defer row.Close()
-	return fetchLogsFromQuery(row)
+	return getLogsFromQuery(row)
 }
 
-func FetchLogsFromRange(logRange LogRange) ([]TransactionLogs, error) {
+func GetLogsFromRange(logRange LogRange) ([]CardLogPreview, error) {
 	db := database.Instance()
 	row, err := db.Query(`
 		SELECT fc.container_id, fc.container_name, tc.container_id, tc.container_name, scryfall_id, amount
 		FROM transactions
 		LEFT JOIN containers AS fc ON from_container_id = fc.container_id
 		LEFT JOIN containers AS tc ON to_container_id = tc.container_id
-		WHERE time >= $1 AND time <= $2;`, logRange.start, logRange.end)
+		WHERE time >= $1 AND time <= $2;`, logRange.Start, logRange.End)
 
 	if err != nil {
 		return nil, err
 	}
 
 	defer row.Close()
-	return fetchLogsFromQuery(row)
+	return getLogsFromQuery(row)
 }
 
-func fetchLogsFromQuery(row *sql.Rows) ([]TransactionLogs, error) {
-	logs := []TransactionLogs{}
+func getLogsFromQuery(row *sql.Rows) ([]CardLogPreview, error) {
+	logs := []CardLogPreview{}
 
 	for row.Next() {
-		log := TransactionLogs{}
+		log := CardLogPreview{}
 
 		var fromMaybeBoxId sql.Null[int]
 		var fromMaybeBoxName sql.NullString
@@ -99,16 +99,16 @@ func fetchLogsFromQuery(row *sql.Rows) ([]TransactionLogs, error) {
 		var toMaybeBoxId sql.Null[int]
 		var toMaybeBoxName sql.NullString
 
-		if err := row.Scan(&fromMaybeBoxId, &fromMaybeBoxName, &toMaybeBoxId, &toMaybeBoxName, &log.ScryfallId, &log.Quantity); err != nil {
+		if err := row.Scan(&fromMaybeBoxId, &fromMaybeBoxName, &toMaybeBoxId, &toMaybeBoxName, &log.ScryfallId, &log.Amount); err != nil {
 			return nil, err
 		}
 
 		if fromMaybeBoxId.Valid && fromMaybeBoxName.Valid {
-			log.FromContainer = &TransactionContainer{fromMaybeBoxId.V, fromMaybeBoxName.String}
+			log.FromContainer = &containers.ContainerName{ContainerId: fromMaybeBoxId.V, Name: fromMaybeBoxName.String}
 		}
 
 		if toMaybeBoxId.Valid && toMaybeBoxName.Valid {
-			log.ToContainer = &TransactionContainer{toMaybeBoxId.V, toMaybeBoxName.String}
+			log.ToContainer = &containers.ContainerName{ContainerId: toMaybeBoxId.V, Name: toMaybeBoxName.String}
 		}
 
 		logs = append(logs, log)

--- a/backend/transactions/types.go
+++ b/backend/transactions/types.go
@@ -8,41 +8,32 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jnie1/MTGViewer-V2/cards"
+	"github.com/jnie1/MTGViewer-V2/containers"
 )
 
 type LogRange struct {
-	start time.Time
-	end   time.Time
+	Start time.Time
+	End   time.Time
 }
 
-type UpdateLogs struct {
+type CardTransaction struct {
 	GroupId uuid.UUID `json:"groupId"`
 	Time    time.Time `json:"time"`
-	Amount  int       `json:"amount"`
+	Total   int       `json:"total"`
 }
 
-type TransactionLogs struct {
-	FromContainer *TransactionContainer `json:"fromContainer"`
-	ToContainer   *TransactionContainer `json:"toContainer"`
-	ScryfallId    uuid.UUID             `json:"scryfallId"`
-	Quantity      int                   `json:"quantity"`
+type CardLogPreview struct {
+	FromContainer *containers.ContainerName
+	ToContainer   *containers.ContainerName
+	ScryfallId    uuid.UUID
+	Amount        int
 }
 
-type TransactionContainer struct {
-	ContainerId int    `json:"containerId"`
-	Name        string `json:"name"`
-}
-
-func (container *TransactionContainer) Container() TransactionContainer {
-	if container == nil {
-		return TransactionContainer{}
-	}
-	return *container
-}
-
-type containerCard struct {
-	containerId int
-	scryfallId  uuid.UUID
+type CardLog struct {
+	FromContainer *containers.ContainerName `json:"fromContainer"`
+	ToContainer   *containers.ContainerName `json:"toContainer"`
+	Card          cards.Card                `json:"card"`
+	Amount        int                       `json:"amount"`
 }
 
 type containerChange struct {
@@ -50,33 +41,28 @@ type containerChange struct {
 	delta       int
 }
 
-type ReportCard struct {
-	FromContainer *TransactionContainer `json:"fromContainer"`
-	ToContainer   *TransactionContainer `json:"toContainer"`
-	Card          cards.Card            `json:"card"`
-	Quantity      int                   `json:"quantity"`
-}
+type containerMappings map[int]*containers.ContainerName
 
-func GetScryfallIds(transactionLogs []TransactionLogs) []cards.ScryfallIdentifier {
+func ToScryfallIds(transactionLogs []CardLogPreview) []cards.ScryfallIdentifier {
 	uniqIds := map[uuid.UUID]any{}
 
 	for _, log := range transactionLogs {
 		uniqIds[log.ScryfallId] = nil
 	}
 
-	allIds := make([]cards.ScryfallIdentifier, len(uniqIds))
+	ids := make([]cards.ScryfallIdentifier, len(uniqIds))
 	i := 0
 
 	for id := range uniqIds {
-		allIds[i] = cards.ScryfallIdentifier{Id: id}
+		ids[i] = cards.ScryfallIdentifier{Id: id}
 		i += 1
 	}
 
-	return allIds
+	return ids
 }
 
-func JoinReportCards(loggedCards []cards.Card, logs []TransactionLogs) ([]ReportCard, error) {
-	reportCards := make([]ReportCard, len(logs))
+func JoinCardLogs(loggedCards []cards.Card, logs []CardLogPreview) ([]CardLog, error) {
+	cardChanges := make([]CardLog, len(logs))
 	cardMap := make(map[uuid.UUID]cards.Card, len(loggedCards))
 
 	for _, loggedCard := range loggedCards {
@@ -88,19 +74,19 @@ func JoinReportCards(loggedCards []cards.Card, logs []TransactionLogs) ([]Report
 		if !ok {
 			return nil, fmt.Errorf("cannot resolve card id %s", log.ScryfallId)
 		}
-		reportCards[i] = ReportCard{
+		cardChanges[i] = CardLog{
 			FromContainer: log.FromContainer,
 			ToContainer:   log.ToContainer,
 			Card:          reportedCard,
-			Quantity:      log.Quantity,
+			Amount:        log.Amount,
 		}
 	}
 
-	slices.SortFunc(reportCards, compareReportCards)
-	return reportCards, nil
+	slices.SortFunc(cardChanges, compareCardChange)
+	return cardChanges, nil
 }
 
-func compareReportCards(a, b ReportCard) int {
+func compareCardChange(a, b CardLog) int {
 	if c := cmp.Compare(a.FromContainer.Container().Name, b.FromContainer.Container().Name); c != 0 {
 		return c
 	}

--- a/backend/transactions/types.go
+++ b/backend/transactions/types.go
@@ -36,13 +36,6 @@ type CardLog struct {
 	Amount        int                       `json:"amount"`
 }
 
-type containerChange struct {
-	containerId int
-	delta       int
-}
-
-type containerMappings map[int]*containers.ContainerName
-
 func ToScryfallIds(transactionLogs []CardLogPreview) []cards.ScryfallIdentifier {
 	uniqIds := map[uuid.UUID]any{}
 

--- a/frontend/src/container/types.ts
+++ b/frontend/src/container/types.ts
@@ -1,0 +1,4 @@
+export interface IContainer {
+  containerId: number;
+  name: string;
+}

--- a/frontend/src/transaction/ChangeLogs.vue
+++ b/frontend/src/transaction/ChangeLogs.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import type { ILogs } from './types';
+import type { ICardTransaction } from './types';
 
 interface ILogsProps {
-  logs: ILogs[];
+  logs: ICardTransaction[];
 }
 
 //assuming i get the right transaction
@@ -26,7 +26,7 @@ const { logs } = defineProps<ILogsProps>();
           </router-link>
         </v-col>
         <v-col>
-          {{ log.amount }}
+          {{ log.total }}
         </v-col>
       </v-row>
     </div>

--- a/frontend/src/transaction/TransactionDetail.vue
+++ b/frontend/src/transaction/TransactionDetail.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import type { ITransactionChange } from './types';
+import type { ICardLog } from './types';
 
 interface ITransactionProps {
-  changes: ITransactionChange[];
+  changes: ICardLog[];
 }
 
 const { changes } = defineProps<ITransactionProps>();
@@ -59,7 +59,7 @@ const { changes } = defineProps<ITransactionProps>();
             {{ change.toContainer.name }}
           </router-link>
         </v-col>
-        <v-col>{{ change.quantity }}</v-col>
+        <v-col>{{ change.amount }}</v-col>
       </v-row>
     </div>
   </div>

--- a/frontend/src/transaction/types.ts
+++ b/frontend/src/transaction/types.ts
@@ -1,19 +1,15 @@
 import { type ICard } from '@/cards/types';
+import type { IContainer } from '@/container/types';
 
-export interface ILogs {
+export interface ICardTransaction {
   groupId: string;
   time: string;
-  amount: number;
+  total: number;
 }
 
-export interface IContainer {
-  containerId: number;
-  name: string;
-}
-
-export interface ITransactionChange {
+export interface ICardLog {
   fromContainer?: IContainer;
   toContainer?: IContainer;
   card: ICard;
-  quantity: number;
+  amount: number;
 }

--- a/frontend/src/views/ChangeView.vue
+++ b/frontend/src/views/ChangeView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { loadRouteData, useRouteData } from '@/fetch/useRouteData';
-import type { ILogs } from '@/transaction/types';
+import type { ICardTransaction } from '@/transaction/types';
 import ChangeLogs from '@/transaction/ChangeLogs.vue';
 
 defineOptions({
@@ -9,7 +9,7 @@ defineOptions({
   },
 });
 
-const logs = useRouteData<ILogs[]>();
+const logs = useRouteData<ICardTransaction[]>();
 </script>
 <template>
   <main>

--- a/frontend/src/views/TransactionView.vue
+++ b/frontend/src/views/TransactionView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { loadRouteData, useRouteData } from '@/fetch/useRouteData';
-import type { ITransactionChange } from '@/transaction/types';
+import type { ICardLog } from '@/transaction/types';
 import TransactionDetail from '@/transaction/TransactionDetail.vue';
 
 defineOptions({
@@ -10,7 +10,7 @@ defineOptions({
   },
 });
 
-const changes = useRouteData<ITransactionChange[]>();
+const changes = useRouteData<ICardLog[]>();
 </script>
 <template>
   <main>


### PR DESCRIPTION
no actual functionality here, purely just name changes

main reasoning is that naming and types were declared all over the place, making type referencing inconsistent and circular referencing very common to happen

method names and properties were also updated to have more clarity, and to avoid circular importing types have the following import flow:

* cards package - no dependencies
* containers package - dependency on cards package
* transactions package - dependencies on cards and containers package