### PR TITLE
Pruning cards

### DIFF
--- a/backend/cards/price.go
+++ b/backend/cards/price.go
@@ -1,0 +1,28 @@
+package cards
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+func FindCheapCards(cards []Card, amounts []CardAmountPreview, price float64) ([]CardAmount, error) {
+	belowPrice := []CardAmount{}
+	amountsById := map[uuid.UUID]int{}
+
+	for _, amt := range amounts {
+		amountsById[amt.ScryfallId] = amt.Amount
+	}
+
+	for _, card := range cards {
+		cardPrice, err := strconv.ParseFloat(card.Prices["usd"], 64)
+		if err != nil {
+			return nil, err
+		}
+		if cardPrice <= price && !strings.Contains(card.Type, "Land") {
+			belowPrice = append(belowPrice, CardAmount{card, amountsById[card.ScryfallId]})
+		}
+	}
+	return belowPrice, nil
+}

--- a/backend/cards/types.go
+++ b/backend/cards/types.go
@@ -15,18 +15,19 @@ type CardImageUrls struct {
 }
 
 type Card struct {
-	ScryfallId      uuid.UUID     `json:"scryfallId"`
-	Name            string        `json:"name"`
-	ManaCost        string        `json:"manaCost,omitempty"`
-	Set             string        `json:"set"`
-	SetCode         string        `json:"set_code"`
-	CollectorNumber string        `json:"collector_number"`
-	MultiverseIds   []int         `json:"multiverse_ids,omitempty"`
-	Type            string        `json:"type"`
-	Rarity          string        `json:"rarity"`
-	Power           string        `json:"power,omitempty"`
-	Toughness       string        `json:"toughness,omitempty"`
-	Images          CardImageUrls `json:"imageUrls"`
+	ScryfallId      uuid.UUID         `json:"scryfallId"`
+	Name            string            `json:"name"`
+	ManaCost        string            `json:"manaCost,omitempty"`
+	Set             string            `json:"set"`
+	SetCode         string            `json:"set_code"`
+	CollectorNumber string            `json:"collector_number"`
+	MultiverseIds   []int             `json:"multiverse_ids,omitempty"`
+	Type            string            `json:"type"`
+	Rarity          string            `json:"rarity"`
+	Power           string            `json:"power,omitempty"`
+	Toughness       string            `json:"toughness,omitempty"`
+	Images          CardImageUrls     `json:"imageUrls"`
+	Prices          map[string]string `json:"prices"`
 }
 
 type CardAmount struct {
@@ -73,6 +74,7 @@ type scryfallCard struct {
 	CardFaces       []scryfallCardFace `json:"card_faces,omitempty"`
 	Type            string             `json:"type_line"`
 	Rarity          string             `json:"rarity"`
+	Prices          map[string]string  `json:"prices"`
 }
 
 type searchResult struct {
@@ -112,6 +114,7 @@ func toCard(card scryfallCard) Card {
 			images.Normal,
 			images.Large,
 		},
+		card.Prices,
 	}
 }
 

--- a/backend/containers/purge.go
+++ b/backend/containers/purge.go
@@ -1,0 +1,5 @@
+package containers
+
+func TranslatePrune(matches []CardDepositPreview, targetCopies int) ([]ContainerChanges, error) {
+	return nil, nil
+}

--- a/backend/containers/purge.go
+++ b/backend/containers/purge.go
@@ -18,7 +18,8 @@ func TranslatePrune(matches []CardDepositPreview, targetCopies int) []ContainerC
 		depositsByCard[scryfallId] = append(depositsByCard[scryfallId], deposit)
 	}
 
-	changesByCard := map[uuid.UUID][]ContainerDelta{}
+	changesByContainer := map[int][]CardRequest{}
+
 	for _, deposits := range depositsByCard {
 		slices.SortFunc(deposits, func(a, b CardDepositPreview) int {
 			// negative to sort in desc order
@@ -32,28 +33,19 @@ func TranslatePrune(matches []CardDepositPreview, targetCopies int) []ContainerC
 			pruneAmount := deposit.Amount - keepAmount
 
 			if pruneAmount > 0 {
-				scryfallId := deposit.ScryfallId
-				delta := ContainerDelta{deposit.ContainerId, -pruneAmount}
-				changesByCard[scryfallId] = append(changesByCard[scryfallId], delta)
+				containerId := deposit.ContainerId
+				request := CardRequest{deposit.ScryfallId, -pruneAmount}
+				changesByContainer[containerId] = append(changesByContainer[containerId], request)
 			}
 
 			remainingCopies -= keepAmount
 		}
 	}
 
-	changesByContainer := map[int][]CardRequest{}
-	for cardId, changes := range changesByCard {
-		for _, change := range changes {
-			containerId := change.ContainerId
-			request := CardRequest{cardId, change.Delta}
-			changesByContainer[containerId] = append(changesByContainer[containerId], request)
-		}
-	}
-
 	changes := make([]ContainerChanges, len(changesByContainer))
 	i := 0
 	for containerId, requests := range changesByContainer {
-		changes[i] = ContainerChanges{containerId, requests}
+		changes[i] = ContainerChanges{containerId, MergeCardRequests(requests)}
 		i += 1
 	}
 

--- a/backend/containers/purge.go
+++ b/backend/containers/purge.go
@@ -1,5 +1,57 @@
 package containers
 
-func TranslatePrune(matches []CardDepositPreview, targetCopies int) ([]ContainerChanges, error) {
-	return nil, nil
+import (
+	"cmp"
+	"slices"
+
+	"github.com/google/uuid"
+)
+
+func TranslatePrune(matches []CardDepositPreview, targetCopies int) []ContainerChanges {
+	if targetCopies < 0 {
+		return nil
+	}
+
+	depositsByCard := map[uuid.UUID][]CardDepositPreview{}
+	for _, deposit := range matches {
+		scryfallId := deposit.ScryfallId
+		depositsByCard[scryfallId] = append(depositsByCard[scryfallId], deposit)
+	}
+
+	changesByCard := map[ContainerCard]int{}
+	for _, deposits := range depositsByCard {
+		slices.SortFunc(deposits, func(a, b CardDepositPreview) int {
+			// negative to sort in desc order
+			return -cmp.Compare(a.Amount, b.Amount)
+		})
+
+		remainingCopies := targetCopies
+
+		for _, deposit := range deposits {
+			keepAmount := min(deposit.Amount, remainingCopies)
+			pruneAmount := deposit.Amount - keepAmount
+
+			if pruneAmount > 0 {
+				cardKey := ContainerCard{deposit.ContainerId, deposit.ScryfallId}
+				changesByCard[cardKey] = changesByCard[cardKey] - pruneAmount
+			}
+			remainingCopies -= keepAmount
+		}
+	}
+
+	changesByContainer := map[int][]CardRequest{}
+	for containerCard, delta := range changesByCard {
+		containerId := containerCard.ContainerId
+		request := CardRequest{containerCard.ScryfallId, delta}
+		changesByContainer[containerId] = append(changesByContainer[containerId], request)
+	}
+
+	changes := make([]ContainerChanges, len(changesByContainer))
+	i := 0
+	for containerId, requests := range changesByContainer {
+		changes[i] = ContainerChanges{containerId, requests}
+		i += 1
+	}
+
+	return changes
 }

--- a/backend/containers/purge.go
+++ b/backend/containers/purge.go
@@ -18,7 +18,7 @@ func TranslatePrune(matches []CardDepositPreview, targetCopies int) []ContainerC
 		depositsByCard[scryfallId] = append(depositsByCard[scryfallId], deposit)
 	}
 
-	changesByCard := map[ContainerCard]int{}
+	changesByCard := map[uuid.UUID][]ContainerDelta{}
 	for _, deposits := range depositsByCard {
 		slices.SortFunc(deposits, func(a, b CardDepositPreview) int {
 			// negative to sort in desc order
@@ -32,18 +32,22 @@ func TranslatePrune(matches []CardDepositPreview, targetCopies int) []ContainerC
 			pruneAmount := deposit.Amount - keepAmount
 
 			if pruneAmount > 0 {
-				cardKey := ContainerCard{deposit.ContainerId, deposit.ScryfallId}
-				changesByCard[cardKey] = changesByCard[cardKey] - pruneAmount
+				scryfallId := deposit.ScryfallId
+				delta := ContainerDelta{deposit.ContainerId, -pruneAmount}
+				changesByCard[scryfallId] = append(changesByCard[scryfallId], delta)
 			}
+
 			remainingCopies -= keepAmount
 		}
 	}
 
 	changesByContainer := map[int][]CardRequest{}
-	for containerCard, delta := range changesByCard {
-		containerId := containerCard.ContainerId
-		request := CardRequest{containerCard.ScryfallId, delta}
-		changesByContainer[containerId] = append(changesByContainer[containerId], request)
+	for cardId, changes := range changesByCard {
+		for _, change := range changes {
+			containerId := change.ContainerId
+			request := CardRequest{cardId, change.Delta}
+			changesByContainer[containerId] = append(changesByContainer[containerId], request)
+		}
 	}
 
 	changes := make([]ContainerChanges, len(changesByContainer))

--- a/backend/containers/purge.go
+++ b/backend/containers/purge.go
@@ -21,12 +21,12 @@ func TranslatePrune(matches []CardDepositPreview, targetCopies int) []ContainerC
 	changesByContainer := map[int][]CardRequest{}
 
 	for _, deposits := range depositsByCard {
+		remainingCopies := targetCopies
+
 		slices.SortFunc(deposits, func(a, b CardDepositPreview) int {
 			// negative to sort in desc order
 			return -cmp.Compare(a.Amount, b.Amount)
 		})
-
-		remainingCopies := targetCopies
 
 		for _, deposit := range deposits {
 			keepAmount := min(deposit.Amount, remainingCopies)

--- a/backend/containers/repository.go
+++ b/backend/containers/repository.go
@@ -109,6 +109,34 @@ func GetAmounts(containerId int) ([]cards.CardAmountPreview, error) {
 	return amounts, nil
 }
 
+func FindExcessAmounts(count int) ([]cards.CardAmountPreview, error) {
+	db := database.Instance()
+
+	row, err := db.Query(`
+		SELECT cd.scryfall_id, SUM(cd.amount)
+		FROM card_deposits cd 
+		GROUP BY cd.scryfall_id 
+		HAVING SUM(cd.amount) > $1;`, count)
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer row.Close()
+	deposits := []cards.CardAmountPreview{}
+
+	for row.Next() {
+		deposit := cards.CardAmountPreview{}
+		if err := row.Scan(&deposit.ScryfallId, &deposit.Amount); err != nil {
+			return nil, err
+		}
+
+		deposits = append(deposits, deposit)
+	}
+
+	return deposits, nil
+}
+
 func SearchDeposits(scryfallIds uuid.UUIDs) ([]CardDepositPreview, error) {
 	db := database.Instance()
 

--- a/backend/routes/containers.go
+++ b/backend/routes/containers.go
@@ -209,10 +209,7 @@ func applyPrune(c *gin.Context) {
 		return
 	}
 
-	changes, err := containers.TranslatePrune(matches, maxCopies)
-	if err != nil {
-		c.AbortWithError(http.StatusInternalServerError, err)
-	}
+	changes := containers.TranslatePrune(matches, maxCopies)
 
 	if err := containers.UpdateDeposits(changes); err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)

--- a/backend/routes/containers.go
+++ b/backend/routes/containers.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jnie1/MTGViewer-V2/cards"
 	"github.com/jnie1/MTGViewer-V2/containers"
+	"github.com/jnie1/MTGViewer-V2/transactions"
 )
 
 func fetchContainerPreviews(c *gin.Context) {
@@ -106,10 +107,132 @@ func searchCards(c *gin.Context) {
 	c.JSON(http.StatusOK, result)
 }
 
+func checkPrune(c *gin.Context) {
+	size := c.Query("size")
+	maxCopies, err := strconv.Atoi(size)
+	if err != nil {
+		c.AbortWithError(http.StatusBadRequest, err)
+		return
+	}
+
+	if maxCopies <= 0 {
+		c.AbortWithStatus(http.StatusBadRequest)
+		return
+	}
+
+	price := c.Query("price")
+	maxPrice, err := strconv.ParseFloat(price, 64)
+	if err != nil {
+		c.AbortWithError(http.StatusBadRequest, err)
+		return
+	}
+
+	if maxPrice <= 0.0 {
+		c.AbortWithStatus(http.StatusBadRequest)
+		return
+	}
+
+	amounts, err := containers.FindExcessAmounts(maxCopies)
+	if err != nil {
+		c.AbortWithError(http.StatusBadRequest, err)
+		return
+	}
+
+	scryfallIds := cards.ToScryfallIds(amounts)
+	matches, err := cards.FetchCollection(scryfallIds)
+	if err != nil {
+		c.AbortWithError(http.StatusBadRequest, err)
+		return
+	}
+
+	result, err := cards.FindCheapCards(matches, amounts, maxPrice)
+	if err != nil {
+		c.AbortWithError(http.StatusBadRequest, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, result)
+}
+
+func applyPrune(c *gin.Context) {
+	size := c.Query("size")
+	maxCopies, err := strconv.Atoi(size)
+	if err != nil {
+		c.AbortWithError(http.StatusBadRequest, err)
+		return
+	}
+
+	if maxCopies <= 0 {
+		c.AbortWithStatus(http.StatusBadRequest)
+		return
+	}
+
+	price := c.Query("price")
+	maxPrice, err := strconv.ParseFloat(price, 64)
+	if err != nil {
+		c.AbortWithError(http.StatusBadRequest, err)
+		return
+	}
+
+	if maxPrice <= 0.0 {
+		c.AbortWithStatus(http.StatusBadRequest)
+		return
+	}
+
+	amounts, err := containers.FindExcessAmounts(maxCopies)
+	if err != nil {
+		c.AbortWithError(http.StatusBadRequest, err)
+		return
+	}
+
+	scryfallIds := cards.ToScryfallIds(amounts)
+	results, err := cards.FetchCollection(scryfallIds)
+	if err != nil {
+		c.AbortWithError(http.StatusBadRequest, err)
+		return
+	}
+
+	cheapCards, err := cards.FindCheapCards(results, amounts, maxPrice)
+	if err != nil {
+		c.AbortWithError(http.StatusBadRequest, err)
+		return
+	}
+
+	cheapIds := make(uuid.UUIDs, len(cheapCards))
+	for i, card := range cheapCards {
+		cheapIds[i] = card.ScryfallId
+	}
+
+	matches, err := containers.SearchDeposits(cheapIds)
+	if err != nil {
+		c.AbortWithError(http.StatusBadRequest, err)
+		return
+	}
+
+	changes, err := containers.TranslatePrune(matches, maxCopies)
+	if err != nil {
+		c.AbortWithError(http.StatusInternalServerError, err)
+	}
+
+	if err := containers.UpdateDeposits(changes); err != nil {
+		c.AbortWithError(http.StatusInternalServerError, err)
+		return
+	}
+
+	if err := transactions.LogCollectionChanges(changes); err != nil {
+		c.AbortWithError(http.StatusInternalServerError, err)
+		return
+	}
+
+	c.Status(http.StatusOK)
+}
+
 func AddContainerRoutes(router *gin.Engine) {
 	group := router.Group("/containers")
 	group.GET("", fetchContainerPreviews)
 	group.GET("/:container", fetchContainer)
 	group.GET("/:container/cards", fetchContainerCards)
 	group.GET("/cards", searchCards)
+	group.GET("/prune", checkPrune)
+	group.POST("/prune", applyPrune)
 }


### PR DESCRIPTION
adds 2 new endpoints for pruning, basically bulk cleaning out cards from storage that are both:

1. cheap
2. way too many copies

the 2 endpoints are used to preview what cards would be purged, and the other endpoint to actually run and apply the purging

what is determined as "cheap" and how many is too many copies is specified as query params to the endpoints