### PR TITLE
added small change to the dockerfile build for autotls support.

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -18,6 +18,7 @@ FROM debian:bookworm-slim
 
 #Grab certificates
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN update-ca-certificates
 
 WORKDIR /mtgviewer-v2
 


### PR DESCRIPTION
Added a line to the dockerfile as per the suggestion of the autotls repository since we are running this in a docker container. You can find it at the bottom of their repository: https://github.com/gin-gonic/autotls.