### PR TITLE
catch all route

### DIFF
--- a/backend/routes/static.go
+++ b/backend/routes/static.go
@@ -9,16 +9,17 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func AddStaticPaths(r *gin.Engine) error {
+func AddStaticRoutes(r *gin.Engine, knownRoutes ...string) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return err
 	}
 
-	indexPath := path.Join(cwd, "dist", "index.html")
-	assetsPath := path.Join(cwd, "dist", "assets")
+	dist := path.Join(cwd, "dist")
+	index := path.Join(dist, "index.html")
+	assets := path.Join(dist, "assets")
 
-	_, err = os.Stat(indexPath)
+	_, err = os.Stat(index)
 	if os.IsNotExist(err) {
 		return nil
 	}
@@ -26,7 +27,7 @@ func AddStaticPaths(r *gin.Engine) error {
 		return err
 	}
 
-	_, err = os.Stat(assetsPath)
+	_, err = os.Stat(assets)
 	if os.IsNotExist(err) {
 		return nil
 	}
@@ -34,8 +35,8 @@ func AddStaticPaths(r *gin.Engine) error {
 		return err
 	}
 
-	r.StaticFile("/", indexPath)
-	r.Static("/assets", assetsPath)
+	r.StaticFile("/", index)
+	r.Static("/assets", assets)
 
 	r.GET("/index", func(c *gin.Context) {
 		c.Redirect(http.StatusMovedPermanently, "/")
@@ -45,11 +46,13 @@ func AddStaticPaths(r *gin.Engine) error {
 	})
 
 	r.NoRoute(func(c *gin.Context) {
-		if strings.HasPrefix(c.Request.URL.Path, "/api/") {
-			c.Status(http.StatusNotFound)
-			return
+		for _, rt := range knownRoutes {
+			if strings.HasPrefix(c.Request.URL.Path, rt) {
+				c.Status(http.StatusNotFound)
+				return
+			}
 		}
-		c.File(indexPath)
+		c.File(index)
 	})
 
 	return nil

--- a/backend/routes/static.go
+++ b/backend/routes/static.go
@@ -34,8 +34,8 @@ func AddStaticPaths(r *gin.Engine) error {
 		return err
 	}
 
-	r.Static("/", indexPath)
-	r.StaticFile("/assets", assetsPath)
+	r.StaticFile("/", indexPath)
+	r.Static("/assets", assetsPath)
 
 	r.GET("/index", func(c *gin.Context) {
 		c.Redirect(http.StatusMovedPermanently, "/")

--- a/backend/routes/static.go
+++ b/backend/routes/static.go
@@ -4,42 +4,52 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 )
 
-func AddStaticPaths(r gin.IRouter) error {
+func AddStaticPaths(r *gin.Engine) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return err
 	}
 
-	routeMap := map[string]string{
-		"/":       path.Join(cwd, "dist/index.html"),
-		"/assets": path.Join(cwd, "dist/assets"),
+	indexPath := path.Join(cwd, "dist", "index.html")
+	assetsPath := path.Join(cwd, "dist", "assets")
+
+	_, err = os.Stat(indexPath)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
 	}
 
-	for route, filepath := range routeMap {
-		stat, err := os.Stat(filepath)
-		if os.IsNotExist(err) {
-			continue
-		}
-		if err != nil {
-			return err
-		}
-		if stat.IsDir() {
-			r.Static(route, filepath)
-		} else {
-			r.StaticFile(route, filepath)
-		}
+	_, err = os.Stat(assetsPath)
+	if os.IsNotExist(err) {
+		return nil
 	}
+	if err != nil {
+		return err
+	}
+
+	r.Static("/", indexPath)
+	r.StaticFile("/assets", assetsPath)
 
 	r.GET("/index", func(c *gin.Context) {
 		c.Redirect(http.StatusMovedPermanently, "/")
 	})
-
 	r.GET("/index.html", func(c *gin.Context) {
 		c.Redirect(http.StatusMovedPermanently, "/")
+	})
+
+	r.NoRoute(func(c *gin.Context) {
+		if strings.HasPrefix(c.Request.URL.Path, "/api/") {
+			c.Status(http.StatusNotFound)
+			return
+		}
+		c.File(indexPath)
 	})
 
 	return nil

--- a/backend/server.go
+++ b/backend/server.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"log"
-	"net/http"
 
 	"github.com/gin-gonic/gin"
 	"github.com/jnie1/MTGViewer-V2/auth"
@@ -20,21 +19,15 @@ func RegisterRouter() {
 	r := gin.Default()
 	r.Use(auth.CorsMiddleware())
 
-	if err := routes.AddStaticPaths(r); err != nil {
-		log.Fatal("Error adding static files: ", err)
-	}
-
 	api := r.Group("/api")
 	routes.AddUserRoutes(api)
 	routes.AddCardRoutes(api)
 	routes.AddContainerRoutes(api)
 	routes.AddTransactionRoutes(api)
 
-	authorized := api.Group("", auth.IsAuthorized)
-
-	authorized.GET("/secret", func(c *gin.Context) {
-		c.JSON(http.StatusAccepted, gin.H{"secret": "some secret"})
-	})
+	if err := routes.AddStaticRoutes(r, "/api"); err != nil {
+		log.Fatal("Error adding static files: ", err)
+	}
 
 	r.Run(":8080")
 }


### PR DESCRIPTION
adds another route to the static routes as a catch all, basically if the backend receives a request that it doesn't have a mapping to, it will now assume it is a frontend route instead of 404