### PR TITLE
swap to webp scryfall images

### DIFF
--- a/backend/cards/scryfall.go
+++ b/backend/cards/scryfall.go
@@ -17,9 +17,12 @@ const (
 )
 
 type scryfallImages struct {
-	Small  string `json:"small,omitempty"`
-	Normal string `json:"normal,omitempty"`
-	Large  string `json:"large,omitempty"`
+	Small   string `json:"small,omitempty"`
+	Normal  string `json:"normal,omitempty"`
+	Large   string `json:"large,omitempty"`
+	Thumb   string `json:"thumb,omitempty"`
+	Grid    string `json:"grid,omitempty"`
+	Display string `json:"display,omitempty"`
 }
 
 type scryfallCardFace struct {
@@ -167,9 +170,9 @@ func toCard(card scryfallCard) Card {
 		card.Power,
 		card.Toughness,
 		CardImageURLs{
-			images.Small,
-			images.Normal,
-			images.Large,
+			images.Thumb,
+			images.Grid,
+			images.Display,
 		},
 	}
 }


### PR DESCRIPTION
webp files are stored in [thumb, grid, display](https://scryfall.com/docs/api/images) which should have the same dims as the jpeg equivalents, but use those for card responses

